### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.13.5
+RUN apk update && \
+    apk add bash g++ git make zlib-dev && \
+    git clone --recurse-submodules https://github.com/bo1929/krepp.git && \
+    cd krepp && \
+    make && \
+    mv krepp /usr/local/bin/krepp && \
+    cd .. && \
+    rm -rf krepp


### PR DESCRIPTION
This PR adds a `Dockerfile` for creating a minimal Docker image with `krepp` installed globally (in `/usr/local/bin`).